### PR TITLE
Add layered cache tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/KyleBanks/depth v1.2.1 // indirect
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
+	github.com/alicebob/miniredis/v2 v2.35.0 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.19.6 // indirect
 	github.com/go-openapi/spec v0.20.4 // indirect
@@ -44,6 +45,7 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/mailru/easyjson v0.7.6 // indirect
 	github.com/swaggo/swag v1.8.12 // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	golang.org/x/tools v0.34.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tN
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
+github.com/alicebob/miniredis/v2 v2.35.0 h1:QwLphYqCEAo1eu1TqPRN2jgVMPBweeQcR21jeqDCONI=
+github.com/alicebob/miniredis/v2 v2.35.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
@@ -193,6 +195,8 @@ github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2
 github.com/ugorji/go/codec v1.3.0 h1:Qd2W2sQawAfG8XSvzwhBeoGq71zXOC/Q1E9y/wUcsUA=
 github.com/ugorji/go/codec v1.3.0/go.mod h1:pRBVtBSKl77K30Bv8R2P+cLSGaTtex6fsA2Wjqmfxj4=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
 go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
 go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin v0.62.0 h1:fZNpsQuTwFFSGC96aJexNOBrCD7PjD9Tm/HyHtXhmnk=

--- a/scripts/calc_indicators.go
+++ b/scripts/calc_indicators.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/testutils/mocks.go
+++ b/tests/testutils/mocks.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"time"
 
-	"github.com/growthfolio/go-priceguard-api/internal/domain/entities"
 	"github.com/google/uuid"
+	"github.com/growthfolio/go-priceguard-api/internal/domain/entities"
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/mock"
 )
@@ -294,8 +294,19 @@ func (m *MockRedisClient) Set(ctx context.Context, key string, value interface{}
 func (m *MockRedisClient) Get(ctx context.Context, key string) *redis.StringCmd {
 	args := m.Called(ctx, key)
 	cmd := redis.NewStringCmd(ctx)
-	if args.Get(0) != nil {
+	if err := args.Error(1); err != nil {
+		cmd.SetErr(err)
+	} else if args.Get(0) != nil {
 		cmd.SetVal(args.String(0))
+	}
+	return cmd
+}
+
+func (m *MockRedisClient) TTL(ctx context.Context, key string) *redis.DurationCmd {
+	args := m.Called(ctx, key)
+	cmd := redis.NewDurationCmd(ctx)
+	if args.Get(0) != nil {
+		cmd.SetVal(args.Get(0).(time.Duration))
 	}
 	return cmd
 }

--- a/tests/unit/adapters/repository/user_repository_test.go
+++ b/tests/unit/adapters/repository/user_repository_test.go
@@ -1,0 +1,1 @@
+package repository_test

--- a/tests/unit/infrastructure/cache/layered_cache_test.go
+++ b/tests/unit/infrastructure/cache/layered_cache_test.go
@@ -1,0 +1,97 @@
+package cache_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/growthfolio/go-priceguard-api/internal/infrastructure/cache"
+	"github.com/redis/go-redis/v9"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func newLayeredCache(t *testing.T) (*cache.LayeredCache, *miniredis.Miniredis, func()) {
+	s := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: s.Addr()})
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+	lc := cache.NewLayeredCache(10, time.Second, rdb, cache.WriteThrough, logger)
+	cleanup := func() {
+		lc.Close()
+		s.Close()
+	}
+	return lc, s, cleanup
+}
+
+func TestLayeredCache_SetGetWithTTL(t *testing.T) {
+	lc, srv, cleanup := newLayeredCache(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	key := "ttl_key"
+	value := map[string]string{"foo": "bar"}
+	ttl := 50 * time.Millisecond
+
+	err := lc.Set(ctx, key, value, ttl)
+	assert.NoError(t, err)
+
+	var out map[string]string
+	found, err := lc.Get(ctx, key, &out)
+	assert.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, value, out)
+
+	time.Sleep(ttl + 20*time.Millisecond)
+	srv.FastForward(ttl + time.Millisecond)
+
+	found, err = lc.Get(ctx, key, &out)
+	assert.NoError(t, err)
+	assert.False(t, found)
+
+	metrics := lc.GetMetrics()
+	assert.Equal(t, int64(1), metrics.L1Stats.Sets)
+	assert.Equal(t, int64(1), metrics.L1Stats.Hits)
+	assert.Equal(t, int64(1), metrics.L1Stats.Misses)
+	assert.Equal(t, int64(1), metrics.L2Stats.Misses)
+}
+
+func TestLayeredCache_PromotionFromRedis(t *testing.T) {
+	s := miniredis.RunT(t)
+	key := "promo_key"
+	value := map[string]string{"foo": "bar"}
+	b, _ := json.Marshal(value)
+	s.Set(key, string(b))
+	ttl := time.Minute
+	s.SetTTL(key, ttl)
+
+	rdb := redis.NewClient(&redis.Options{Addr: s.Addr()})
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+	lc := cache.NewLayeredCache(10, time.Second, rdb, cache.WriteThrough, logger)
+	defer func() {
+		lc.Close()
+		s.Close()
+	}()
+
+	ctx := context.Background()
+	var out map[string]string
+	found, err := lc.Get(ctx, key, &out)
+	assert.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, value, out)
+
+	var out2 map[string]string
+	found, err = lc.Get(ctx, key, &out2)
+	assert.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, value, out2)
+
+	metrics := lc.GetMetrics()
+	assert.Equal(t, int64(1), metrics.L1Stats.Hits)
+	assert.Equal(t, int64(1), metrics.L1Stats.Misses)
+	assert.Equal(t, int64(1), metrics.L2Stats.Hits)
+	assert.Equal(t, int64(0), metrics.L2Stats.Misses)
+}


### PR DESCRIPTION
## Summary
- add unit tests for layered cache
- extend redis mock with TTL and error support
- ensure invalid script isn't built
- fix empty test package

## Testing
- `go test ./tests/unit/infrastructure/cache -run TestLayeredCache -count=1`
- `go test ./...` *(fails: near "(": syntax error and other integration test errors)*

------
https://chatgpt.com/codex/tasks/task_e_688534368bbc83319d81351a80a7449e